### PR TITLE
feat(cli): validate and extend background color flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ go install github.com/taigrr/trophy/cmd/trophy@latest
 trophy model.glb              # View a GLB model
 trophy model.obj              # View an OBJ model
 trophy model.stl              # View an STL model
+trophy info model.glb         # Show model stats without opening the viewer
 trophy -texture tex.png model.obj  # Apply custom texture
 trophy -bg 0,0,0 model.glb    # Black background
+trophy -bg '#101820' model.glb # Hex background color
 trophy -fps 60 model.glb      # Higher framerate
 ```
 

--- a/cmd/trophy/main.go
+++ b/cmd/trophy/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -76,7 +77,7 @@ Controls:
 
 	cmd.Flags().StringVar(&texturePath, "texture", "", "Path to texture image (PNG/JPG)")
 	cmd.Flags().IntVar(&targetFPS, "fps", 60, "Target FPS")
-	cmd.Flags().StringVar(&bgColor, "bg", "", "Background color (R,G,B)")
+	cmd.Flags().StringVar(&bgColor, "bg", "", "Background color (R,G,B or #RRGGBB)")
 
 	// Add info subcommand
 	infoCmd := &cobra.Command{
@@ -364,12 +365,52 @@ func (v *ViewState) ScreenToLightDir(screenX, screenY, width, height int) math3d
 	return math3d.V3(nx, -ny, nz).Normalize()
 }
 
+func parseBackgroundColor(input string) (color.RGBA, error) {
+	value := strings.TrimSpace(input)
+	if value == "" {
+		return color.RGBA{}, nil
+	}
+
+	if strings.HasPrefix(value, "#") {
+		if len(value) != 7 {
+			return color.RGBA{}, fmt.Errorf("invalid hex color %q: expected #RRGGBB", input)
+		}
+		red, err := strconv.ParseUint(value[1:3], 16, 8)
+		if err != nil {
+			return color.RGBA{}, fmt.Errorf("invalid hex color %q: %w", input, err)
+		}
+		green, err := strconv.ParseUint(value[3:5], 16, 8)
+		if err != nil {
+			return color.RGBA{}, fmt.Errorf("invalid hex color %q: %w", input, err)
+		}
+		blue, err := strconv.ParseUint(value[5:7], 16, 8)
+		if err != nil {
+			return color.RGBA{}, fmt.Errorf("invalid hex color %q: %w", input, err)
+		}
+		return color.RGBA{R: uint8(red), G: uint8(green), B: uint8(blue), A: 255}, nil
+	}
+
+	parts := strings.Split(value, ",")
+	if len(parts) != 3 {
+		return color.RGBA{}, fmt.Errorf("invalid background color %q: expected R,G,B or #RRGGBB", input)
+	}
+
+	channels := make([]uint8, 3)
+	for index, part := range parts {
+		channel, err := strconv.ParseUint(strings.TrimSpace(part), 10, 8)
+		if err != nil {
+			return color.RGBA{}, fmt.Errorf("invalid background color %q: %w", input, err)
+		}
+		channels[index] = uint8(channel)
+	}
+
+	return color.RGBA{R: channels[0], G: channels[1], B: channels[2], A: 255}, nil
+}
+
 func run(modelPath string) (err error) {
-	// Parse background color
-	var bg color.RGBA
-	if bgColor != "" {
-		fmt.Sscanf(bgColor, "%d,%d,%d", &bg.R, &bg.G, &bg.B)
-		bg.A = 255
+	bg, err := parseBackgroundColor(bgColor)
+	if err != nil {
+		return err
 	}
 
 	// Create terminal

--- a/cmd/trophy/main_test.go
+++ b/cmd/trophy/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"image/color"
 	"math"
 	"testing"
 
@@ -218,6 +219,39 @@ func TestScreenToLightDirSymmetry(t *testing.T) {
 	}
 	if math.Abs(left.Z-right.Z) > 0.001 {
 		t.Errorf("expected same Z: left.Z=%f, right.Z=%f", left.Z, right.Z)
+	}
+}
+
+func TestParseBackgroundColorRGB(t *testing.T) {
+	parsed, err := parseBackgroundColor("12, 34,56")
+	if err != nil {
+		t.Fatalf("parseBackgroundColor returned error: %v", err)
+	}
+
+	expected := color.RGBA{R: 12, G: 34, B: 56, A: 255}
+	if parsed != expected {
+		t.Fatalf("expected %+v, got %+v", expected, parsed)
+	}
+}
+
+func TestParseBackgroundColorHex(t *testing.T) {
+	parsed, err := parseBackgroundColor("#0A1B2C")
+	if err != nil {
+		t.Fatalf("parseBackgroundColor returned error: %v", err)
+	}
+
+	expected := color.RGBA{R: 0x0A, G: 0x1B, B: 0x2C, A: 255}
+	if parsed != expected {
+		t.Fatalf("expected %+v, got %+v", expected, parsed)
+	}
+}
+
+func TestParseBackgroundColorInvalid(t *testing.T) {
+	testCases := []string{"12,34", "12,34,999", "#12345", "#GG0000"}
+	for _, testCase := range testCases {
+		if _, err := parseBackgroundColor(testCase); err == nil {
+			t.Fatalf("expected error for %q", testCase)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate `--bg` values instead of silently accepting malformed input
- add `#RRGGBB` support alongside the existing `R,G,B` format
- document the `info` subcommand and hex background example in the README

## Testing
- go test -race ./...
- staticcheck ./...
- git diff --check