### PR TITLE
fix: prefer base-color texture for GLB rendering

### DIFF
--- a/pkg/models/gltf.go
+++ b/pkg/models/gltf.go
@@ -557,7 +557,7 @@ func LoadGLTFWithTextures(path string) (*Mesh, map[int][]byte, error) {
 	return mesh, textures, nil
 }
 
-// LoadGLBWithTexture loads a GLB file and returns the mesh plus the first embedded texture.
+// LoadGLBWithTexture loads a GLB file and returns the mesh plus its primary base-color texture.
 // Returns (mesh, texture image, error). Texture may be nil if none embedded.
 func LoadGLBWithTexture(path string) (*Mesh, image.Image, error) {
 	mesh, textures, err := LoadGLTFWithTextures(path)
@@ -565,17 +565,38 @@ func LoadGLBWithTexture(path string) (*Mesh, image.Image, error) {
 		return nil, nil, err
 	}
 
-	// Find the first texture
-	var textureImg image.Image
-	for _, data := range textures {
-		if len(data) > 0 {
-			img, _, err := image.Decode(bytes.NewReader(data))
-			if err == nil {
-				textureImg = img
-				break
+	if textureImg := selectPrimaryGLTFTexture(mesh, textures); textureImg != nil {
+		return mesh, textureImg, nil
+	}
+
+	return mesh, nil, nil
+}
+
+func selectPrimaryGLTFTexture(mesh *Mesh, textures map[int][]byte) image.Image {
+	if mesh != nil {
+		for _, face := range mesh.Faces {
+			material := mesh.GetMaterial(face.Material)
+			if material != nil && material.HasTexture && material.BaseMap != nil {
+				return material.BaseMap
+			}
+		}
+
+		for _, material := range mesh.Materials {
+			if material.HasTexture && material.BaseMap != nil {
+				return material.BaseMap
 			}
 		}
 	}
 
-	return mesh, textureImg, nil
+	for _, data := range textures {
+		if len(data) == 0 {
+			continue
+		}
+		img, _, err := image.Decode(bytes.NewReader(data))
+		if err == nil {
+			return img
+		}
+	}
+
+	return nil
 }

--- a/pkg/models/gltf_texture_selection_test.go
+++ b/pkg/models/gltf_texture_selection_test.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSelectPrimaryGLTFTexturePrefersFaceMaterialBaseMap(t *testing.T) {
+	wrong := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	wrong.Set(0, 0, color.RGBA{R: 255, A: 255})
+
+	correct := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	correct.Set(0, 0, color.RGBA{G: 255, A: 255})
+
+	mesh := &Mesh{
+		Materials: []Material{
+			{Name: "normal", BaseMap: wrong, HasTexture: true},
+			{Name: "base", BaseMap: correct, HasTexture: true},
+		},
+		Faces: []Face{{Material: 1}},
+	}
+
+	textures := map[int][]byte{0: mustEncodePNG(t, wrong), 1: mustEncodePNG(t, correct)}
+
+	selected := selectPrimaryGLTFTexture(mesh, textures)
+	if selected == nil {
+		t.Fatal("expected selected texture")
+	}
+
+	r, g, b, _ := selected.At(0, 0).RGBA()
+	if r>>8 != 0 || g>>8 != 255 || b>>8 != 0 {
+		t.Fatalf("selected wrong texture: got (%d,%d,%d)", r>>8, g>>8, b>>8)
+	}
+}
+
+func TestSelectPrimaryGLTFTextureFallsBackToDecodableTexture(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{B: 255, A: 255})
+
+	selected := selectPrimaryGLTFTexture(nil, map[int][]byte{
+		0: []byte("not an image"),
+		1: mustEncodePNG(t, img),
+	})
+	if selected == nil {
+		t.Fatal("expected fallback texture")
+	}
+
+	r, g, b, _ := selected.At(0, 0).RGBA()
+	if r>>8 != 0 || g>>8 != 0 || b>>8 != 255 {
+		t.Fatalf("fallback selected wrong texture: got (%d,%d,%d)", r>>8, g>>8, b>>8)
+	}
+}
+
+func mustEncodePNG(t *testing.T, img image.Image) []byte {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "texture.png")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create temp png: %v", err)
+	}
+
+	if err := png.Encode(file, img); err != nil {
+		file.Close()
+		t.Fatalf("encode png: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close png: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read png: %v", err)
+	}
+
+	return data
+}


### PR DESCRIPTION
## Summary
- choose the base-color texture referenced by the mesh material instead of a random decoded image
- fall back to the first decodable embedded texture only when material metadata is unavailable
- add tests covering material-based selection and fallback behavior

Closes #14

## Testing
- go test ./...