### PR TITLE
fix(cli): validate target fps

### DIFF
--- a/cmd/trophy/main.go
+++ b/cmd/trophy/main.go
@@ -49,6 +49,8 @@ var (
 	bgColor     string
 )
 
+const minTargetFPS = 1
+
 func main() {
 	cmd := &cobra.Command{
 		Use:   "trophy <model.obj|model.glb|model.stl>",
@@ -407,7 +409,18 @@ func parseBackgroundColor(input string) (color.RGBA, error) {
 	return color.RGBA{R: channels[0], G: channels[1], B: channels[2], A: 255}, nil
 }
 
+func validateTargetFPS(fps int) error {
+	if fps < minTargetFPS {
+		return fmt.Errorf("invalid fps %d: must be at least %d", fps, minTargetFPS)
+	}
+	return nil
+}
+
 func run(modelPath string) (err error) {
+	if err := validateTargetFPS(targetFPS); err != nil {
+		return err
+	}
+
 	bg, err := parseBackgroundColor(bgColor)
 	if err != nil {
 		return err

--- a/cmd/trophy/main_test.go
+++ b/cmd/trophy/main_test.go
@@ -255,6 +255,22 @@ func TestParseBackgroundColorInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateTargetFPS(t *testing.T) {
+	for _, testCase := range []int{1, 30, 60, 120} {
+		if err := validateTargetFPS(testCase); err != nil {
+			t.Fatalf("validateTargetFPS(%d) returned error: %v", testCase, err)
+		}
+	}
+}
+
+func TestValidateTargetFPSInvalid(t *testing.T) {
+	for _, testCase := range []int{0, -1, -60} {
+		if err := validateTargetFPS(testCase); err == nil {
+			t.Fatalf("expected error for fps %d", testCase)
+		}
+	}
+}
+
 func TestRunInfoUnsupportedFormat(t *testing.T) {
 	err := runInfo("test.xyz")
 	if err == nil {


### PR DESCRIPTION
## Summary
- reject zero and negative `--fps` values before terminal setup
- add tests for valid and invalid FPS inputs

## Tests
- go generate ./...
- go test -race ./...
- staticcheck ./...